### PR TITLE
Add missing xelatex latex_module. I'm not sure how this got lost.

### DIFF
--- a/rubber/latex_modules/xelatex.py
+++ b/rubber/latex_modules/xelatex.py
@@ -1,0 +1,12 @@
+from rubber import _, msg
+
+
+def setup(doc, context):
+    doc.vars['program'] = 'xelatex'
+    doc.vars['engine'] = 'XeLaTeX'
+
+    if doc.env.final != doc and doc.products[0][-4:] != '.pdf':
+        msg.error(_("there is already a post-processor registered"))
+        return
+
+    doc.reset_products([doc.target + '.pdf'])


### PR DESCRIPTION
Your repo is missing the `xelatex.py` module so compilation of `.tex` files that require `xelatex` break. For some bizarre reason `rubber` silently ignores `rubber: module xelatex` directives (or the `-m` flag if a non existent module is specified)  and just tries to use `latex` instead breaking compilation... eurgh.
