### PR TITLE
Support symbolic links to the rubber command

### DIFF
--- a/README
+++ b/README
@@ -14,7 +14,8 @@ dependency relations or post-compilation diagnostics.
 * Running directly from the repository
 
 It is possible to run rubber directly from the repository without installation.
-Just add the ``bin/`` directory to your PATH.
+Just add the ``bin/`` directory to your PATH, or add a symbolic link
+to the repository's ``bin/rubber`` from a file in your existing PATH.
 
 * Installation
 

--- a/bin/rubber
+++ b/bin/rubber
@@ -4,7 +4,7 @@
 # directly from within the repository
 import os
 import sys
-repo_root = os.path.dirname(os.path.dirname(__file__))
+repo_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, repo_root)
 
 from rubber.cmdline import script_entry_point

--- a/bin/rubber-info
+++ b/bin/rubber-info
@@ -4,7 +4,7 @@
 # directly from within the repository
 import os
 import sys
-repo_root = os.path.dirname(os.path.dirname(__file__))
+repo_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, repo_root)
 
 from rubber.cmd_info import script_entry_point

--- a/bin/rubber-pipe
+++ b/bin/rubber-pipe
@@ -4,7 +4,7 @@
 # directly from within the repository
 import os
 import sys
-repo_root = os.path.dirname(os.path.dirname(__file__))
+repo_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.insert(0, repo_root)
 
 from rubber.cmd_pipe import script_entry_point


### PR DESCRIPTION
This allows the program's installation through a symbolic link
to the repository.